### PR TITLE
Add type variable to load() to prevent losing type information

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ export function useLoading() {
   };
   return [isLoading, load] as [
     boolean,
-    (aPromise: Promise<any>) => Promise<any>
+    <T>(aPromise: Promise<T>) => Promise<T>
   ];
 }
 


### PR DESCRIPTION
Currently, the function returned by useLoading() takes a generic `Promise<any>` and also returns a generic `Promise<any>` (while it always returns the same promise that was passed in). Thus, any type information about the promise is erased to `any`. With this commit, the promise's value's type is preserved.